### PR TITLE
Update astradb_haystack_integration.ipynb

### DIFF
--- a/notebooks/astradb_haystack_integration.ipynb
+++ b/notebooks/astradb_haystack_integration.ipynb
@@ -149,10 +149,9 @@
         "import os\n",
         "\n",
         "os.environ[\"OPENAI_API_KEY\"] = getpass(\"Enter your openAI key:\")\n",
-        "os.environ[\"ASTRA_API_ENDPOINT\"] = getpass(\"Enter your Astra API Endpoint:\")\n",
-        "os.environ[\"ASTRA_TOKEN\"] = getpass(\"Enter your Astra application token (e.g.AstraCS:xxx ):\")\n",
+        "os.environ[\"ASTRA_DB_API_ENDPOINT\"] = getpass(\"Enter your Astra API Endpoint:\")\n",
+        "os.environ[\"ASTRA_DB_APPLICATION_TOKEN\"] = getpass(\"Enter your Astra application token (e.g.AstraCS:xxx ):\")\n",
         "ASTRA_DB_COLLECTION_NAME = getpass(\"enter your Astra collection name:\")\n",
-        "ASTRA_DB_KEYSPACE_NAME = getpass(\"Enter your Astra keyspace name:\")"
       ]
     },
     {
@@ -237,7 +236,6 @@
         "# embedding_dim is the number of dimensions the embedding model supports.\n",
         "document_store = AstraDocumentStore(\n",
         "    astra_collection=ASTRA_DB_COLLECTION_NAME,\n",
-        "    astra_keyspace=ASTRA_DB_KEYSPACE_NAME,\n",
         "    duplicates_policy=DuplicatePolicy.SKIP,\n",
         "    embedding_dim=384,\n",
         ")\n",


### PR DESCRIPTION
Update according to https://github.com/deepset-ai/haystack-core-integrations/pull/428/files

- Env vars renamed to ASTRA_DB_API_ENDPOINT and ASTRA_DB_APPLICATION_TOKEN
- Removed the key_space parameter