### PR TITLE
Update import path of `Pipeline`

### DIFF
--- a/notebooks/amazon_bedrock_for_documentation_qa.ipynb
+++ b/notebooks/amazon_bedrock_for_documentation_qa.ipynb
@@ -250,7 +250,7 @@
    "outputs": [],
    "source": [
     "from haystack.components.builders import PromptBuilder\n",
-    "from haystack.pipeline import Pipeline\n",
+    "from haystack import Pipeline\n",
     "from haystack_integrations.components.generators.amazon_bedrock import AmazonBedrockGenerator\n",
     "from haystack_integrations.components.retrievers.opensearch import OpenSearchBM25Retriever\n",
     "\n",

--- a/notebooks/amazon_sagemaker_and_chroma_for_qa.ipynb
+++ b/notebooks/amazon_sagemaker_and_chroma_for_qa.ipynb
@@ -227,7 +227,7 @@
    },
    "outputs": [],
    "source": [
-    "from haystack.pipeline import Pipeline\n",
+    "from haystack import Pipeline\n",
     "from haystack.components.builders import PromptBuilder\n",
     "from haystack_integrations.components.generators.amazon_sagemaker import SagemakerGenerator\n",
     "from haystack_integrations.components.retrievers.chroma import ChromaQueryTextRetriever\n",


### PR DESCRIPTION
The new beta release breaks the old import path of the `Pipeline` class. I am updating the import paths in two notebooks.

Related PRs: https://github.com/deepset-ai/haystack/pull/6973 and https://github.com/deepset-ai/haystack-tutorials/pull/285