### PR TITLE
install trafilatura

### DIFF
--- a/notebooks/information-extraction-gorilla.ipynb
+++ b/notebooks/information-extraction-gorilla.ipynb
@@ -81,7 +81,7 @@
       "outputs": [],
       "source": [
         "%%capture\n",
-        "! pip install transformers accelerate bitsandbytes haystack-ai"
+        "! pip install transformers accelerate bitsandbytes haystack-ai trafilatura"
       ]
     },
     {

--- a/notebooks/information_extraction_raven.ipynb
+++ b/notebooks/information_extraction_raven.ipynb
@@ -81,7 +81,7 @@
       "outputs": [],
       "source": [
         "%%capture\n",
-        "! pip install haystack-ai \"huggingface_hub>=0.22.0\""
+        "! pip install haystack-ai \"huggingface_hub>=0.22.0\" trafilatura"
       ]
     },
     {

--- a/notebooks/mixtral-8x7b-for-web-qa.ipynb
+++ b/notebooks/mixtral-8x7b-for-web-qa.ipynb
@@ -36,7 +36,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install haystack-ai boilerpy3 sentence_transformers \"huggingface_hub>=0.22.0\""
+        "!pip install haystack-ai trafilatura sentence_transformers \"huggingface_hub>=0.22.0\""
       ]
     },
     {

--- a/notebooks/vertexai-gemini-examples.ipynb
+++ b/notebooks/vertexai-gemini-examples.ipynb
@@ -64,7 +64,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install --upgrade haystack-ai google-vertex-haystack"
+        "!pip install --upgrade haystack-ai google-vertex-haystack trafilatura"
       ]
     },
     {


### PR DESCRIPTION
In https://github.com/deepset-ai/haystack/pull/7809, `trafilatura` (backend library for `HTMLToDocument`) was made optional.

In this PR, I am explicitly installing this library in the notebooks that use `HTMLToDocument`.