### PR TITLE
Remove context relevancy metric from Ragas notebook

### DIFF
--- a/notebooks/rag_eval_ragas.ipynb
+++ b/notebooks/rag_eval_ragas.ipynb
@@ -9,7 +9,7 @@
         "# RAG pipeline evaluation using Ragas\n",
         "\n",
         "[Ragas](https://docs.ragas.io/en/stable/) is a framework to evaluate [Retrieval Augmented Generation](https://www.deepset.ai/blog/llms-retrieval-augmentation) (RAG) pipelines.\n",
-        "It supports metrics like context relevance, answer correctness, faithfulness, and more.\n",
+        "It supports metrics like context utilization, answer correctness, faithfulness, and more.\n",
         "\n",
         "For more information about evaluators, supported metrics and usage, check out:\n",
         "\n",
@@ -824,87 +824,6 @@
       "source": [
         "evaluation_results = context_recall_pipeline.run(\n",
         "    {\"evaluator\": {\"questions\": questions, \"contexts\": contexts, \"ground_truths\": ground_truths}}\n",
-        ")\n",
-        "print(evaluation_results[\"evaluator\"][\"results\"])\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "C_91cVvZEfuk"
-      },
-      "source": [
-        "### Context Relevancy\n",
-        "\n",
-        "Context relevancy measures the relevancy of the `retrieved context`, calculated based on both the `question` and `contexts`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 195,
-      "metadata": {
-        "id": "eIQqeX7cF_a6"
-      },
-      "outputs": [],
-      "source": [
-        "from haystack import Pipeline\n",
-        "from haystack_integrations.components.evaluators.ragas import RagasEvaluator, RagasMetric\n",
-        "\n",
-        "context_relevancy_pipeline = Pipeline()\n",
-        "evaluator = RagasEvaluator(metric=RagasMetric.CONTEXT_RELEVANCY)\n",
-        "context_relevancy_pipeline.add_component(\"evaluator\", evaluator)\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 196,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 67,
-          "referenced_widgets": [
-            "c4888e5a79ac49caa9226469e32b42df",
-            "49356c242ca94c85b9949d1e1e99830e",
-            "eabbe690d9554684895dfcd861a27e69",
-            "f0e7327506f94dfd9ef2f36f68d03a16",
-            "9b678872296c4e9f9a943edd4bd13cca",
-            "c131143b42ab4d3b98247c2a2c8312aa",
-            "a97e9bcee4bd4ec6b9e8a84e428f52f5",
-            "56cb56c2b9a14be1a8e2892ccabbed9e",
-            "f30331a7e8f746a488e582edbcc6888b",
-            "e6061304170b49898a2bcdfb4ff0c297",
-            "a64db0d7a8e748fc855a0b2049ba1fbd"
-          ]
-        },
-        "id": "XCfENS79GCsj",
-        "outputId": "e4ad2762-a16e-4bbb-e972-dab3335e8feb"
-      },
-      "outputs": [
-        {
-          "data": {
-            "application/vnd.jupyter.widget-view+json": {
-              "model_id": "c4888e5a79ac49caa9226469e32b42df",
-              "version_major": 2,
-              "version_minor": 0
-            },
-            "text/plain": [
-              "Evaluating:   0%|          | 0/3 [00:00<?, ?it/s]"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "[[{'name': 'context_relevancy', 'score': 0.0}], [{'name': 'context_relevancy', 'score': 0.08333333333333333}], [{'name': 'context_relevancy', 'score': 0.0}]]\n"
-          ]
-        }
-      ],
-      "source": [
-        "evaluation_results = context_relevancy_pipeline.run(\n",
-        "    {\"evaluator\": {\"questions\": questions, \"contexts\": contexts}}\n",
         ")\n",
         "print(evaluation_results[\"evaluator\"][\"results\"])\n"
       ]


### PR DESCRIPTION
This metric was removed in ragas [0.1.11](https://github.com/explodinggradients/ragas/releases/tag/v0.1.11).

Then I updated our integration in https://github.com/deepset-ai/haystack-core-integrations/pull/917.

In this PR, I'm removing mentions to context relevancy in Ragas notebook