### PR TITLE
fix: chroma-indexing example - fix querying.run(...)

### DIFF
--- a/notebooks/chroma-indexing-and-rag-examples.ipynb
+++ b/notebooks/chroma-indexing-and-rag-examples.ipynb
@@ -184,7 +184,7 @@
       "outputs": [],
       "source": [
         "query = \"Should I write documentation for my plugin?\"\n",
-        "results = querying.run({\"retriever\": {\"queries\": [query], \"top_k\": 3},\n",
+        "results = querying.run({\"retriever\": {\"query\": query, \"top_k\": 3},\n",
         "                        \"prompt_builder\": {\"query\": query},\n",
         "                        \"llm\":{\"generation_kwargs\": {\"max_new_tokens\": 350}}})"
       ]


### PR DESCRIPTION
`ChromaQueryTextRetriever` expects single query `"query": query` instead of "queries": [query]