### PR TITLE
remove vertexai preview package from imports

### DIFF
--- a/notebooks/vertexai-gemini-examples.ipynb
+++ b/notebooks/vertexai-gemini-examples.ipynb
@@ -299,7 +299,7 @@
       },
       "outputs": [],
       "source": [
-        "from vertexai.preview.generative_models import Tool, FunctionDeclaration\n",
+        "from vertexai.generative_models import Tool, FunctionDeclaration\n",
         "\n",
         "get_current_weather_func = FunctionDeclaration(\n",
         "    name=\"get_current_weather\",\n",


### PR DESCRIPTION
We have migrated from `preview` to stable package for vertexai.