### PR TITLE
fix: removing dead links from auto-merging-retriever tutorial

### DIFF
--- a/notebooks/auto_merging_retriever.ipynb
+++ b/notebooks/auto_merging_retriever.ipynb
@@ -11,10 +11,7 @@
         "This notebook shows how to use experimetnal components for Haystack: `AutoMergingRetriever` and `HierarchicalDocumentSplitter`.\n",
         "\n",
         "- 📚[Read the full article here](https://haystack.deepset.ai/blog/improve-retrieval-with-auto-merging)\n",
-        "- 🙏 Please [join the discussion for these experimental components](https://github.com/deepset-ai/haystack-experimental/discussions/78)\n",
-        "- Documentation for [`AutoMergingRetriever`](https://docs.haystack.deepset.ai/reference/auto-merge-retriever)\n",
-        "- Documentation for [`HierarchicalDocumentSplitter`](https://docs.haystack.deepset.ai/reference/hierarchical-document-splitter)\n",
-        "- This is material part of the blog post on the Auto-Merging Retriever - add link here"
+        "- 🙏 Please [join the discussion for these experimental components](https://github.com/deepset-ai/haystack-experimental/discussions/78)\n"
       ]
     },
     {


### PR DESCRIPTION
- fix: removing dead links from auto-merging-retriever tutorial