### PR TITLE
Fixing issues in astradb cookbook

### DIFF
--- a/notebooks/astradb_haystack_integration.ipynb
+++ b/notebooks/astradb_haystack_integration.ipynb
@@ -291,7 +291,7 @@
     "\n",
     "\n",
     "# Draw the pipeline\n",
-    "rag_pipeline.draw(\"./rag_pipeline.png\")\n",
+    "rag_pipeline.draw(path=\"./rag_pipeline.png\")\n",
     "\n",
     "\n",
     "# Run the pipeline\n",


### PR DESCRIPTION
The modifications solve the issue: #256.
Use new parameter names in `AstraDocumentStore `initialization.
Pass path as a keyword argument to `draw()` (it doesn't accept positional arguments).