### PR TITLE
feat: Update conversational rag cookbook

### DIFF
--- a/notebooks/conversational_rag_using_memory.ipynb
+++ b/notebooks/conversational_rag_using_memory.ipynb
@@ -641,7 +641,7 @@
     "If any questions are asked about the seven wonders always use the `rag_tool` to fetch supporting documents.\n",
     "Stay concise in your answers.\n",
     "\"\"\",\n",
-    "        chat_generator=OpenAIChatGenerator(),\n",
+    "        chat_generator=OpenAIChatGenerator(model=\"gpt-4o\"),\n",
     "        tools=[rag_tool],\n",
     "        streaming_callback=print_streaming_chunk,\n",
     "    )\n",


### PR DESCRIPTION
- partially addresses https://github.com/deepset-ai/haystack-private/issues/233

Updates the cookbook to use the new versions of the Chat Message Store components and highlights the `chat_history_id` to easily switch to new sessions or go back to old ones. 

Still a work in progress. Need to finalize the language and probably show some examples of how the chat history can be inspected. Basically provide more concrete proof that the chat history is being fetched as expected. 