### PR TITLE
chore: pin GitHub Actions to specific commit SHAs

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -10,7 +10,7 @@ jobs:
     name: Add new issues to project for triage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1.0.2
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/orgs/deepset-ai/projects/5
           github-token: ${{ secrets.GH_PROJECT_PAT }}

--- a/.github/workflows/verify_index.yml
+++ b/.github/workflows/verify_index.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions in workflow files to immutable full-length commit SHAs instead of mutable tags (e.g. `@v1`, `@v4`)
- Used [pinact](https://github.com/suzuki-shunsuke/pinact) to automatically resolve and apply the correct SHAs
- Version tags are preserved as inline comments for readability (e.g. `# v4.3.1`)

## Motivation

Mutable tags can be silently updated by action authors, which creates a supply chain attack vector. Pinning to a specific commit SHA ensures the exact code being run never changes unexpectedly.
See https://github.com/deepset-ai/haystack-private/issues/137 and https://github.com/deepset-ai/haystack/pull/10896 for more details.
I investigated a bit if the inline comments work with dependabot PRs that update the commit hash.
It seems to work well.

## Affected workflows

- `verify_index.yml` — 2 actions pinned
- `project.yml` — 1 action pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)