### PR TITLE
refactor: replace OutputAdapter in using_hyde_for_improved_retrieval notebook

### DIFF
--- a/notebooks/using_hyde_for_improved_retrieval.ipynb
+++ b/notebooks/using_hyde_for_improved_retrieval.ipynb
@@ -19,7 +19,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -27,9 +27,131 @@
         "id": "_ZIUJlvQCDvF",
         "outputId": "2879cabf-1d6e-49c4-ab60-17c2688f88ea"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Collecting haystack-ai\n",
+            "  Using cached haystack_ai-2.26.1-py3-none-any.whl.metadata (14 kB)\n",
+            "Requirement already satisfied: sentence-transformers in /opt/anaconda3/lib/python3.13/site-packages (5.1.0)\n",
+            "Collecting datasets\n",
+            "  Downloading datasets-4.8.4-py3-none-any.whl.metadata (19 kB)\n",
+            "Collecting docstring-parser (from haystack-ai)\n",
+            "  Using cached docstring_parser-0.17.0-py3-none-any.whl.metadata (3.5 kB)\n",
+            "Collecting filetype (from haystack-ai)\n",
+            "  Using cached filetype-1.2.0-py2.py3-none-any.whl.metadata (6.5 kB)\n",
+            "Collecting haystack-experimental (from haystack-ai)\n",
+            "  Using cached haystack_experimental-0.19.0-py3-none-any.whl.metadata (16 kB)\n",
+            "Requirement already satisfied: jinja2 in /opt/anaconda3/lib/python3.13/site-packages (from haystack-ai) (3.1.6)\n",
+            "Requirement already satisfied: jsonschema in /opt/anaconda3/lib/python3.13/site-packages (from haystack-ai) (4.23.0)\n",
+            "Collecting lazy-imports (from haystack-ai)\n",
+            "  Using cached lazy_imports-1.2.0-py3-none-any.whl.metadata (11 kB)\n",
+            "Requirement already satisfied: markupsafe in /opt/anaconda3/lib/python3.13/site-packages (from haystack-ai) (3.0.2)\n",
+            "Requirement already satisfied: more-itertools in /opt/anaconda3/lib/python3.13/site-packages (from haystack-ai) (10.3.0)\n",
+            "Requirement already satisfied: networkx in /opt/anaconda3/lib/python3.13/site-packages (from haystack-ai) (3.4.2)\n",
+            "Requirement already satisfied: numpy in /opt/anaconda3/lib/python3.13/site-packages (from haystack-ai) (2.1.3)\n",
+            "Requirement already satisfied: openai>=1.99.2 in /opt/anaconda3/lib/python3.13/site-packages (from haystack-ai) (1.107.1)\n",
+            "Collecting posthog!=3.12.0 (from haystack-ai)\n",
+            "  Using cached posthog-7.9.12-py3-none-any.whl.metadata (6.5 kB)\n",
+            "Requirement already satisfied: pydantic in /opt/anaconda3/lib/python3.13/site-packages (from haystack-ai) (2.10.3)\n",
+            "Requirement already satisfied: python-dateutil in /opt/anaconda3/lib/python3.13/site-packages (from haystack-ai) (2.9.0.post0)\n",
+            "Requirement already satisfied: pyyaml in /opt/anaconda3/lib/python3.13/site-packages (from haystack-ai) (6.0.2)\n",
+            "Requirement already satisfied: requests in /opt/anaconda3/lib/python3.13/site-packages (from haystack-ai) (2.32.3)\n",
+            "Requirement already satisfied: tenacity!=8.4.0 in /opt/anaconda3/lib/python3.13/site-packages (from haystack-ai) (9.0.0)\n",
+            "Requirement already satisfied: tqdm in /opt/anaconda3/lib/python3.13/site-packages (from haystack-ai) (4.67.1)\n",
+            "Requirement already satisfied: typing-extensions>=4.7 in /opt/anaconda3/lib/python3.13/site-packages (from haystack-ai) (4.12.2)\n",
+            "Requirement already satisfied: transformers<5.0.0,>=4.41.0 in /opt/anaconda3/lib/python3.13/site-packages (from sentence-transformers) (4.56.1)\n",
+            "Requirement already satisfied: torch>=1.11.0 in /opt/anaconda3/lib/python3.13/site-packages (from sentence-transformers) (2.8.0)\n",
+            "Requirement already satisfied: scikit-learn in /opt/anaconda3/lib/python3.13/site-packages (from sentence-transformers) (1.6.1)\n",
+            "Requirement already satisfied: scipy in /opt/anaconda3/lib/python3.13/site-packages (from sentence-transformers) (1.15.3)\n",
+            "Requirement already satisfied: huggingface-hub>=0.20.0 in /opt/anaconda3/lib/python3.13/site-packages (from sentence-transformers) (0.34.4)\n",
+            "Requirement already satisfied: Pillow in /opt/anaconda3/lib/python3.13/site-packages (from sentence-transformers) (11.0.0)\n",
+            "Requirement already satisfied: filelock in /opt/anaconda3/lib/python3.13/site-packages (from transformers<5.0.0,>=4.41.0->sentence-transformers) (3.17.0)\n",
+            "Requirement already satisfied: packaging>=20.0 in /opt/anaconda3/lib/python3.13/site-packages (from transformers<5.0.0,>=4.41.0->sentence-transformers) (24.2)\n",
+            "Requirement already satisfied: regex!=2019.12.17 in /opt/anaconda3/lib/python3.13/site-packages (from transformers<5.0.0,>=4.41.0->sentence-transformers) (2024.11.6)\n",
+            "Requirement already satisfied: tokenizers<=0.23.0,>=0.22.0 in /opt/anaconda3/lib/python3.13/site-packages (from transformers<5.0.0,>=4.41.0->sentence-transformers) (0.22.0)\n",
+            "Requirement already satisfied: safetensors>=0.4.3 in /opt/anaconda3/lib/python3.13/site-packages (from transformers<5.0.0,>=4.41.0->sentence-transformers) (0.6.2)\n",
+            "Requirement already satisfied: fsspec>=2023.5.0 in /opt/anaconda3/lib/python3.13/site-packages (from huggingface-hub>=0.20.0->sentence-transformers) (2025.3.2)\n",
+            "Requirement already satisfied: hf-xet<2.0.0,>=1.1.3 in /opt/anaconda3/lib/python3.13/site-packages (from huggingface-hub>=0.20.0->sentence-transformers) (1.1.9)\n",
+            "Collecting pyarrow>=21.0.0 (from datasets)\n",
+            "  Downloading pyarrow-23.0.1-cp313-cp313-macosx_12_0_arm64.whl.metadata (3.1 kB)\n",
+            "Requirement already satisfied: dill<0.4.2,>=0.3.0 in /opt/anaconda3/lib/python3.13/site-packages (from datasets) (0.3.8)\n",
+            "Requirement already satisfied: pandas in /opt/anaconda3/lib/python3.13/site-packages (from datasets) (2.2.3)\n",
+            "Requirement already satisfied: httpx<1.0.0 in /opt/anaconda3/lib/python3.13/site-packages (from datasets) (0.28.1)\n",
+            "Collecting xxhash (from datasets)\n",
+            "  Using cached xxhash-3.6.0-cp313-cp313-macosx_11_0_arm64.whl.metadata (13 kB)\n",
+            "Collecting multiprocess<0.70.20 (from datasets)\n",
+            "  Downloading multiprocess-0.70.19-py313-none-any.whl.metadata (7.5 kB)\n",
+            "Requirement already satisfied: aiohttp!=4.0.0a0,!=4.0.0a1 in /opt/anaconda3/lib/python3.13/site-packages (from fsspec[http]<=2026.2.0,>=2023.1.0->datasets) (3.11.10)\n",
+            "Requirement already satisfied: anyio in /opt/anaconda3/lib/python3.13/site-packages (from httpx<1.0.0->datasets) (4.7.0)\n",
+            "Requirement already satisfied: certifi in /opt/anaconda3/lib/python3.13/site-packages (from httpx<1.0.0->datasets) (2025.10.5)\n",
+            "Requirement already satisfied: httpcore==1.* in /opt/anaconda3/lib/python3.13/site-packages (from httpx<1.0.0->datasets) (1.0.9)\n",
+            "Requirement already satisfied: idna in /opt/anaconda3/lib/python3.13/site-packages (from httpx<1.0.0->datasets) (3.7)\n",
+            "Requirement already satisfied: h11>=0.16 in /opt/anaconda3/lib/python3.13/site-packages (from httpcore==1.*->httpx<1.0.0->datasets) (0.16.0)\n",
+            "Collecting dill<0.4.2,>=0.3.0 (from datasets)\n",
+            "  Downloading dill-0.4.1-py3-none-any.whl.metadata (10 kB)\n",
+            "Requirement already satisfied: aiohappyeyeballs>=2.3.0 in /opt/anaconda3/lib/python3.13/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2026.2.0,>=2023.1.0->datasets) (2.4.4)\n",
+            "Requirement already satisfied: aiosignal>=1.1.2 in /opt/anaconda3/lib/python3.13/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2026.2.0,>=2023.1.0->datasets) (1.2.0)\n",
+            "Requirement already satisfied: attrs>=17.3.0 in /opt/anaconda3/lib/python3.13/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2026.2.0,>=2023.1.0->datasets) (24.3.0)\n",
+            "Requirement already satisfied: frozenlist>=1.1.1 in /opt/anaconda3/lib/python3.13/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2026.2.0,>=2023.1.0->datasets) (1.5.0)\n",
+            "Requirement already satisfied: multidict<7.0,>=4.5 in /opt/anaconda3/lib/python3.13/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2026.2.0,>=2023.1.0->datasets) (6.1.0)\n",
+            "Requirement already satisfied: propcache>=0.2.0 in /opt/anaconda3/lib/python3.13/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2026.2.0,>=2023.1.0->datasets) (0.3.1)\n",
+            "Requirement already satisfied: yarl<2.0,>=1.17.0 in /opt/anaconda3/lib/python3.13/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2026.2.0,>=2023.1.0->datasets) (1.18.0)\n",
+            "Requirement already satisfied: distro<2,>=1.7.0 in /opt/anaconda3/lib/python3.13/site-packages (from openai>=1.99.2->haystack-ai) (1.9.0)\n",
+            "Requirement already satisfied: jiter<1,>=0.4.0 in /opt/anaconda3/lib/python3.13/site-packages (from openai>=1.99.2->haystack-ai) (0.10.0)\n",
+            "Requirement already satisfied: sniffio in /opt/anaconda3/lib/python3.13/site-packages (from openai>=1.99.2->haystack-ai) (1.3.0)\n",
+            "Requirement already satisfied: annotated-types>=0.6.0 in /opt/anaconda3/lib/python3.13/site-packages (from pydantic->haystack-ai) (0.6.0)\n",
+            "Requirement already satisfied: pydantic-core==2.27.1 in /opt/anaconda3/lib/python3.13/site-packages (from pydantic->haystack-ai) (2.27.1)\n",
+            "Requirement already satisfied: six>=1.5 in /opt/anaconda3/lib/python3.13/site-packages (from posthog!=3.12.0->haystack-ai) (1.17.0)\n",
+            "Collecting backoff>=1.10.0 (from posthog!=3.12.0->haystack-ai)\n",
+            "  Using cached backoff-2.2.1-py3-none-any.whl.metadata (14 kB)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /opt/anaconda3/lib/python3.13/site-packages (from requests->haystack-ai) (3.3.2)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /opt/anaconda3/lib/python3.13/site-packages (from requests->haystack-ai) (2.3.0)\n",
+            "Requirement already satisfied: setuptools in /opt/anaconda3/lib/python3.13/site-packages (from torch>=1.11.0->sentence-transformers) (80.9.0)\n",
+            "Requirement already satisfied: sympy>=1.13.3 in /opt/anaconda3/lib/python3.13/site-packages (from torch>=1.11.0->sentence-transformers) (1.13.3)\n",
+            "Requirement already satisfied: mpmath<1.4,>=1.1.0 in /opt/anaconda3/lib/python3.13/site-packages (from sympy>=1.13.3->torch>=1.11.0->sentence-transformers) (1.3.0)\n",
+            "Requirement already satisfied: jsonschema-specifications>=2023.03.6 in /opt/anaconda3/lib/python3.13/site-packages (from jsonschema->haystack-ai) (2023.7.1)\n",
+            "Requirement already satisfied: referencing>=0.28.4 in /opt/anaconda3/lib/python3.13/site-packages (from jsonschema->haystack-ai) (0.30.2)\n",
+            "Requirement already satisfied: rpds-py>=0.7.1 in /opt/anaconda3/lib/python3.13/site-packages (from jsonschema->haystack-ai) (0.22.3)\n",
+            "Requirement already satisfied: pytz>=2020.1 in /opt/anaconda3/lib/python3.13/site-packages (from pandas->datasets) (2024.1)\n",
+            "Requirement already satisfied: tzdata>=2022.7 in /opt/anaconda3/lib/python3.13/site-packages (from pandas->datasets) (2025.2)\n",
+            "Requirement already satisfied: joblib>=1.2.0 in /opt/anaconda3/lib/python3.13/site-packages (from scikit-learn->sentence-transformers) (1.4.2)\n",
+            "Requirement already satisfied: threadpoolctl>=3.1.0 in /opt/anaconda3/lib/python3.13/site-packages (from scikit-learn->sentence-transformers) (3.5.0)\n",
+            "Using cached haystack_ai-2.26.1-py3-none-any.whl (690 kB)\n",
+            "Downloading datasets-4.8.4-py3-none-any.whl (526 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m527.0/527.0 kB\u001b[0m \u001b[31m5.3 MB/s\u001b[0m  \u001b[33m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading multiprocess-0.70.19-py313-none-any.whl (156 kB)\n",
+            "Downloading dill-0.4.1-py3-none-any.whl (120 kB)\n",
+            "Using cached posthog-7.9.12-py3-none-any.whl (202 kB)\n",
+            "Using cached backoff-2.2.1-py3-none-any.whl (15 kB)\n",
+            "Downloading pyarrow-23.0.1-cp313-cp313-macosx_12_0_arm64.whl (34.2 MB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m34.2/34.2 MB\u001b[0m \u001b[31m4.0 MB/s\u001b[0m  \u001b[33m0:00:08\u001b[0mm0:00:01\u001b[0m00:01\u001b[0m\n",
+            "\u001b[?25hUsing cached docstring_parser-0.17.0-py3-none-any.whl (36 kB)\n",
+            "Using cached filetype-1.2.0-py2.py3-none-any.whl (19 kB)\n",
+            "Using cached haystack_experimental-0.19.0-py3-none-any.whl (63 kB)\n",
+            "Using cached lazy_imports-1.2.0-py3-none-any.whl (18 kB)\n",
+            "Using cached xxhash-3.6.0-cp313-cp313-macosx_11_0_arm64.whl (30 kB)\n",
+            "Installing collected packages: filetype, xxhash, pyarrow, lazy-imports, docstring-parser, dill, backoff, posthog, multiprocess, datasets, haystack-experimental, haystack-ai\n",
+            "\u001b[2K  Attempting uninstall: pyarrow\n",
+            "\u001b[2K    Found existing installation: pyarrow 19.0.0\n",
+            "\u001b[2K    Uninstalling pyarrow-19.0.0:\n",
+            "\u001b[2K      Successfully uninstalled pyarrow-19.0.0\n",
+            "\u001b[2K  Attempting uninstall: dill\u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m 2/12\u001b[0m [pyarrow]\n",
+            "\u001b[2K    Found existing installation: dill 0.3.8━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m 2/12\u001b[0m [pyarrow]\n",
+            "\u001b[2K    Uninstalling dill-0.3.8:m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m 2/12\u001b[0m [pyarrow]\n",
+            "\u001b[2K      Successfully uninstalled dill-0.3.8━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m 2/12\u001b[0m [pyarrow]\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m12/12\u001b[0m [haystack-ai]\u001b[0m [haystack-ai]\n",
+            "\u001b[1A\u001b[2KSuccessfully installed backoff-2.2.1 datasets-4.8.4 dill-0.4.1 docstring-parser-0.17.0 filetype-1.2.0 haystack-ai-2.26.1 haystack-experimental-0.19.0 lazy-imports-1.2.0 multiprocess-0.70.19 posthog-7.9.12 pyarrow-23.0.1 xxhash-3.6.0\n",
+            "\n",
+            "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m25.2\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m26.0.1\u001b[0m\n",
+            "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
+            "Note: you may need to restart the kernel to use updated packages.\n"
+          ]
+        }
+      ],
       "source": [
-        "!pip install haystack-ai sentence-transformers datasets"
+        "%pip install haystack-ai sentence-transformers datasets"
       ]
     },
     {
@@ -43,7 +165,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 2,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -73,11 +195,19 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 3,
       "metadata": {
         "id": "q7vs3ubjB7PB"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "PromptBuilder has 1 prompt variables, but `required_variables` is not set. By default, all prompt variables are treated as optional, which may lead to unintended behavior in multi-branch pipelines. To avoid unexpected execution, ensure that variables intended to be required are explicitly set in `required_variables`.\n"
+          ]
+        }
+      ],
       "source": [
         "from haystack.components.generators.openai import OpenAIGenerator\n",
         "from haystack.components.builders import PromptBuilder\n",
@@ -100,29 +230,38 @@
         "id": "dJVyxytsG6Zc"
       },
       "source": [
-        "Next, we use the `OutputAdapter` to transform the generated paragraphs into a List of Documents. This way, we will be able to use the `SentenceTransformersDocumentEmbedder` to create embeddings, since this component expects `List[Document]`"
+        "Next, we convert the generated paragraphs into a list of `Document` objects.\n",
+        "This allows us to pass them to the `SentenceTransformersDocumentEmbedder`,\n",
+        "which expects `List[Document]` as input."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 4,
       "metadata": {
         "id": "K72gcW84CFtT"
       },
       "outputs": [],
       "source": [
-        "from haystack import Document\n",
-        "from haystack.components.converters import OutputAdapter\n",
+        "from haystack import Document, component\n",
         "from haystack.components.embedders import SentenceTransformersDocumentEmbedder\n",
-        "from typing import List\n",
+        "from typing import Any, List\n",
         "\n",
-        "adapter = OutputAdapter(\n",
-        "    template=\"{{answers | build_doc}}\",\n",
-        "    output_type=List[Document],\n",
-        "    custom_filters={\"build_doc\": lambda data: [Document(content=d) for d in data]}\n",
-        ")\n",
+        "@component\n",
+        "class RepliesToDocuments:\n",
+        "    @component.output_types(documents=List[Document])\n",
+        "    def run(self, replies: List[Any]):\n",
+        "        docs = []\n",
+        "        for reply in replies:\n",
+        "            content = reply.text if hasattr(reply, \"text\") else str(reply)\n",
+        "            docs.append(Document(content=content))\n",
+        "        return {\"documents\": docs}\n",
         "\n",
-        "embedder = SentenceTransformersDocumentEmbedder(model=\"sentence-transformers/all-MiniLM-L6-v2\")"
+        "adapter = RepliesToDocuments()\n",
+        "\n",
+        "embedder = SentenceTransformersDocumentEmbedder(\n",
+        "    model=\"sentence-transformers/all-MiniLM-L6-v2\"\n",
+        ")"
       ]
     },
     {
@@ -136,7 +275,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 6,
       "metadata": {
         "id": "5A7nb9MaCXTH"
       },
@@ -167,7 +306,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 7,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -189,7 +328,31 @@
         "id": "2sa91tDQCaHC",
         "outputId": "92359ba0-26e0-4ba0-85a1-5b9740d4ba66"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "ename": "PipelineRuntimeError",
+          "evalue": "The following component failed to run:\nComponent name: 'generator'\nComponent type: 'OpenAIGenerator'\nError: Error code: 429 - {'error': {'message': 'You exceeded your current quota, please check your plan and billing details. For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors.', 'type': 'insufficient_quota', 'param': None, 'code': 'insufficient_quota'}}",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+            "\u001b[0;31mRateLimitError\u001b[0m                            Traceback (most recent call last)",
+            "File \u001b[0;32m/opt/anaconda3/lib/python3.13/site-packages/haystack/core/pipeline/pipeline.py:84\u001b[0m, in \u001b[0;36mPipeline._run_component\u001b[0;34m(component_name, component, inputs, component_visits, parent_span, break_point)\u001b[0m\n\u001b[1;32m     83\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m---> 84\u001b[0m     component_output \u001b[38;5;241m=\u001b[39m instance\u001b[38;5;241m.\u001b[39mrun(\u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39minputs_copy)\n\u001b[1;32m     85\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m BreakpointException \u001b[38;5;28;01mas\u001b[39;00m error:\n\u001b[1;32m     86\u001b[0m     \u001b[38;5;66;03m# Re-raise BreakpointException to preserve the original exception context\u001b[39;00m\n\u001b[1;32m     87\u001b[0m     \u001b[38;5;66;03m# This is important when Agent components internally use Pipeline._run_component\u001b[39;00m\n\u001b[1;32m     88\u001b[0m     \u001b[38;5;66;03m# and trigger breakpoints that need to bubble up to the main pipeline\u001b[39;00m\n",
+            "File \u001b[0;32m/opt/anaconda3/lib/python3.13/site-packages/haystack/components/generators/openai.py:232\u001b[0m, in \u001b[0;36mOpenAIGenerator.run\u001b[0;34m(self, prompt, system_prompt, streaming_callback, generation_kwargs)\u001b[0m\n\u001b[1;32m    230\u001b[0m openai_formatted_messages \u001b[38;5;241m=\u001b[39m [message\u001b[38;5;241m.\u001b[39mto_openai_dict_format() \u001b[38;5;28;01mfor\u001b[39;00m message \u001b[38;5;129;01min\u001b[39;00m messages]\n\u001b[0;32m--> 232\u001b[0m completion: Stream[ChatCompletionChunk] \u001b[38;5;241m|\u001b[39m ChatCompletion \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mclient\u001b[38;5;241m.\u001b[39mchat\u001b[38;5;241m.\u001b[39mcompletions\u001b[38;5;241m.\u001b[39mcreate(\n\u001b[1;32m    233\u001b[0m     model\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmodel,\n\u001b[1;32m    234\u001b[0m     messages\u001b[38;5;241m=\u001b[39mopenai_formatted_messages,  \u001b[38;5;66;03m# type: ignore\u001b[39;00m\n\u001b[1;32m    235\u001b[0m     stream\u001b[38;5;241m=\u001b[39mstreaming_callback \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m    236\u001b[0m     \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mgeneration_kwargs,\n\u001b[1;32m    237\u001b[0m )\n\u001b[1;32m    239\u001b[0m completions: \u001b[38;5;28mlist\u001b[39m[ChatMessage] \u001b[38;5;241m=\u001b[39m []\n",
+            "File \u001b[0;32m/opt/anaconda3/lib/python3.13/site-packages/openai/_utils/_utils.py:286\u001b[0m, in \u001b[0;36mrequired_args.<locals>.inner.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    285\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m(msg)\n\u001b[0;32m--> 286\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m func(\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39mkwargs)\n",
+            "File \u001b[0;32m/opt/anaconda3/lib/python3.13/site-packages/openai/resources/chat/completions/completions.py:1147\u001b[0m, in \u001b[0;36mCompletions.create\u001b[0;34m(self, messages, model, audio, frequency_penalty, function_call, functions, logit_bias, logprobs, max_completion_tokens, max_tokens, metadata, modalities, n, parallel_tool_calls, prediction, presence_penalty, prompt_cache_key, reasoning_effort, response_format, safety_identifier, seed, service_tier, stop, store, stream, stream_options, temperature, tool_choice, tools, top_logprobs, top_p, user, verbosity, web_search_options, extra_headers, extra_query, extra_body, timeout)\u001b[0m\n\u001b[1;32m   1146\u001b[0m validate_response_format(response_format)\n\u001b[0;32m-> 1147\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_post(\n\u001b[1;32m   1148\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m/chat/completions\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[1;32m   1149\u001b[0m     body\u001b[38;5;241m=\u001b[39mmaybe_transform(\n\u001b[1;32m   1150\u001b[0m         {\n\u001b[1;32m   1151\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mmessages\u001b[39m\u001b[38;5;124m\"\u001b[39m: messages,\n\u001b[1;32m   1152\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mmodel\u001b[39m\u001b[38;5;124m\"\u001b[39m: model,\n\u001b[1;32m   1153\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124maudio\u001b[39m\u001b[38;5;124m\"\u001b[39m: audio,\n\u001b[1;32m   1154\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mfrequency_penalty\u001b[39m\u001b[38;5;124m\"\u001b[39m: frequency_penalty,\n\u001b[1;32m   1155\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mfunction_call\u001b[39m\u001b[38;5;124m\"\u001b[39m: function_call,\n\u001b[1;32m   1156\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mfunctions\u001b[39m\u001b[38;5;124m\"\u001b[39m: functions,\n\u001b[1;32m   1157\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mlogit_bias\u001b[39m\u001b[38;5;124m\"\u001b[39m: logit_bias,\n\u001b[1;32m   1158\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mlogprobs\u001b[39m\u001b[38;5;124m\"\u001b[39m: logprobs,\n\u001b[1;32m   1159\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mmax_completion_tokens\u001b[39m\u001b[38;5;124m\"\u001b[39m: max_completion_tokens,\n\u001b[1;32m   1160\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mmax_tokens\u001b[39m\u001b[38;5;124m\"\u001b[39m: max_tokens,\n\u001b[1;32m   1161\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mmetadata\u001b[39m\u001b[38;5;124m\"\u001b[39m: metadata,\n\u001b[1;32m   1162\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mmodalities\u001b[39m\u001b[38;5;124m\"\u001b[39m: modalities,\n\u001b[1;32m   1163\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mn\u001b[39m\u001b[38;5;124m\"\u001b[39m: n,\n\u001b[1;32m   1164\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mparallel_tool_calls\u001b[39m\u001b[38;5;124m\"\u001b[39m: parallel_tool_calls,\n\u001b[1;32m   1165\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mprediction\u001b[39m\u001b[38;5;124m\"\u001b[39m: prediction,\n\u001b[1;32m   1166\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mpresence_penalty\u001b[39m\u001b[38;5;124m\"\u001b[39m: presence_penalty,\n\u001b[1;32m   1167\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mprompt_cache_key\u001b[39m\u001b[38;5;124m\"\u001b[39m: prompt_cache_key,\n\u001b[1;32m   1168\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mreasoning_effort\u001b[39m\u001b[38;5;124m\"\u001b[39m: reasoning_effort,\n\u001b[1;32m   1169\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mresponse_format\u001b[39m\u001b[38;5;124m\"\u001b[39m: response_format,\n\u001b[1;32m   1170\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124msafety_identifier\u001b[39m\u001b[38;5;124m\"\u001b[39m: safety_identifier,\n\u001b[1;32m   1171\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mseed\u001b[39m\u001b[38;5;124m\"\u001b[39m: seed,\n\u001b[1;32m   1172\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mservice_tier\u001b[39m\u001b[38;5;124m\"\u001b[39m: service_tier,\n\u001b[1;32m   1173\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mstop\u001b[39m\u001b[38;5;124m\"\u001b[39m: stop,\n\u001b[1;32m   1174\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mstore\u001b[39m\u001b[38;5;124m\"\u001b[39m: store,\n\u001b[1;32m   1175\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mstream\u001b[39m\u001b[38;5;124m\"\u001b[39m: stream,\n\u001b[1;32m   1176\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mstream_options\u001b[39m\u001b[38;5;124m\"\u001b[39m: stream_options,\n\u001b[1;32m   1177\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtemperature\u001b[39m\u001b[38;5;124m\"\u001b[39m: temperature,\n\u001b[1;32m   1178\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtool_choice\u001b[39m\u001b[38;5;124m\"\u001b[39m: tool_choice,\n\u001b[1;32m   1179\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtools\u001b[39m\u001b[38;5;124m\"\u001b[39m: tools,\n\u001b[1;32m   1180\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtop_logprobs\u001b[39m\u001b[38;5;124m\"\u001b[39m: top_logprobs,\n\u001b[1;32m   1181\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtop_p\u001b[39m\u001b[38;5;124m\"\u001b[39m: top_p,\n\u001b[1;32m   1182\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124muser\u001b[39m\u001b[38;5;124m\"\u001b[39m: user,\n\u001b[1;32m   1183\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mverbosity\u001b[39m\u001b[38;5;124m\"\u001b[39m: verbosity,\n\u001b[1;32m   1184\u001b[0m             \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mweb_search_options\u001b[39m\u001b[38;5;124m\"\u001b[39m: web_search_options,\n\u001b[1;32m   1185\u001b[0m         },\n\u001b[1;32m   1186\u001b[0m         completion_create_params\u001b[38;5;241m.\u001b[39mCompletionCreateParamsStreaming\n\u001b[1;32m   1187\u001b[0m         \u001b[38;5;28;01mif\u001b[39;00m stream\n\u001b[1;32m   1188\u001b[0m         \u001b[38;5;28;01melse\u001b[39;00m completion_create_params\u001b[38;5;241m.\u001b[39mCompletionCreateParamsNonStreaming,\n\u001b[1;32m   1189\u001b[0m     ),\n\u001b[1;32m   1190\u001b[0m     options\u001b[38;5;241m=\u001b[39mmake_request_options(\n\u001b[1;32m   1191\u001b[0m         extra_headers\u001b[38;5;241m=\u001b[39mextra_headers, extra_query\u001b[38;5;241m=\u001b[39mextra_query, extra_body\u001b[38;5;241m=\u001b[39mextra_body, timeout\u001b[38;5;241m=\u001b[39mtimeout\n\u001b[1;32m   1192\u001b[0m     ),\n\u001b[1;32m   1193\u001b[0m     cast_to\u001b[38;5;241m=\u001b[39mChatCompletion,\n\u001b[1;32m   1194\u001b[0m     stream\u001b[38;5;241m=\u001b[39mstream \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28;01mFalse\u001b[39;00m,\n\u001b[1;32m   1195\u001b[0m     stream_cls\u001b[38;5;241m=\u001b[39mStream[ChatCompletionChunk],\n\u001b[1;32m   1196\u001b[0m )\n",
+            "File \u001b[0;32m/opt/anaconda3/lib/python3.13/site-packages/openai/_base_client.py:1259\u001b[0m, in \u001b[0;36mSyncAPIClient.post\u001b[0;34m(self, path, cast_to, body, options, files, stream, stream_cls)\u001b[0m\n\u001b[1;32m   1256\u001b[0m opts \u001b[38;5;241m=\u001b[39m FinalRequestOptions\u001b[38;5;241m.\u001b[39mconstruct(\n\u001b[1;32m   1257\u001b[0m     method\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mpost\u001b[39m\u001b[38;5;124m\"\u001b[39m, url\u001b[38;5;241m=\u001b[39mpath, json_data\u001b[38;5;241m=\u001b[39mbody, files\u001b[38;5;241m=\u001b[39mto_httpx_files(files), \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39moptions\n\u001b[1;32m   1258\u001b[0m )\n\u001b[0;32m-> 1259\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m cast(ResponseT, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mrequest(cast_to, opts, stream\u001b[38;5;241m=\u001b[39mstream, stream_cls\u001b[38;5;241m=\u001b[39mstream_cls))\n",
+            "File \u001b[0;32m/opt/anaconda3/lib/python3.13/site-packages/openai/_base_client.py:1047\u001b[0m, in \u001b[0;36mSyncAPIClient.request\u001b[0;34m(self, cast_to, options, stream, stream_cls)\u001b[0m\n\u001b[1;32m   1046\u001b[0m     log\u001b[38;5;241m.\u001b[39mdebug(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mRe-raising status error\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m-> 1047\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_make_status_error_from_response(err\u001b[38;5;241m.\u001b[39mresponse) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[1;32m   1049\u001b[0m \u001b[38;5;28;01mbreak\u001b[39;00m\n",
+            "\u001b[0;31mRateLimitError\u001b[0m: Error code: 429 - {'error': {'message': 'You exceeded your current quota, please check your plan and billing details. For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors.', 'type': 'insufficient_quota', 'param': None, 'code': 'insufficient_quota'}}",
+            "\nThe above exception was the direct cause of the following exception:\n",
+            "\u001b[0;31mPipelineRuntimeError\u001b[0m                      Traceback (most recent call last)",
+            "Cell \u001b[0;32mIn[7], line 18\u001b[0m\n\u001b[1;32m     15\u001b[0m pipeline\u001b[38;5;241m.\u001b[39mconnect(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124membedder.documents\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mhyde.documents\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m     17\u001b[0m query \u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mWhat should I do if I have a fever?\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m---> 18\u001b[0m result \u001b[38;5;241m=\u001b[39m pipeline\u001b[38;5;241m.\u001b[39mrun(data\u001b[38;5;241m=\u001b[39m{\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mprompt_builder\u001b[39m\u001b[38;5;124m\"\u001b[39m: {\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mquestion\u001b[39m\u001b[38;5;124m\"\u001b[39m: query}})\n",
+            "File \u001b[0;32m/opt/anaconda3/lib/python3.13/site-packages/haystack/core/pipeline/pipeline.py:423\u001b[0m, in \u001b[0;36mPipeline.run\u001b[0;34m(self, data, include_outputs_from, break_point, pipeline_snapshot, snapshot_callback)\u001b[0m\n\u001b[1;32m    417\u001b[0m     full_file_path \u001b[38;5;241m=\u001b[39m _save_pipeline_snapshot(\n\u001b[1;32m    418\u001b[0m         pipeline_snapshot\u001b[38;5;241m=\u001b[39mpipeline_snapshot,\n\u001b[1;32m    419\u001b[0m         raise_on_failure\u001b[38;5;241m=\u001b[39m\u001b[38;5;28misinstance\u001b[39m(error, BreakpointException),\n\u001b[1;32m    420\u001b[0m         snapshot_callback\u001b[38;5;241m=\u001b[39msnapshot_callback,\n\u001b[1;32m    421\u001b[0m     )\n\u001b[1;32m    422\u001b[0m     error\u001b[38;5;241m.\u001b[39mpipeline_snapshot_file_path \u001b[38;5;241m=\u001b[39m full_file_path\n\u001b[0;32m--> 423\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m error\n\u001b[1;32m    425\u001b[0m \u001b[38;5;66;03m# Updates global input state with component outputs and returns outputs that should go to\u001b[39;00m\n\u001b[1;32m    426\u001b[0m \u001b[38;5;66;03m# pipeline outputs.\u001b[39;00m\n\u001b[1;32m    427\u001b[0m component_pipeline_outputs \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_write_component_outputs(\n\u001b[1;32m    428\u001b[0m     component_name\u001b[38;5;241m=\u001b[39mcomponent_name,\n\u001b[1;32m    429\u001b[0m     component_outputs\u001b[38;5;241m=\u001b[39mcomponent_outputs,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    432\u001b[0m     include_outputs_from\u001b[38;5;241m=\u001b[39minclude_outputs_from,\n\u001b[1;32m    433\u001b[0m )\n",
+            "File \u001b[0;32m/opt/anaconda3/lib/python3.13/site-packages/haystack/core/pipeline/pipeline.py:373\u001b[0m, in \u001b[0;36mPipeline.run\u001b[0;34m(self, data, include_outputs_from, break_point, pipeline_snapshot, snapshot_callback)\u001b[0m\n\u001b[1;32m    370\u001b[0m     component_inputs[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124msnapshot_callback\u001b[39m\u001b[38;5;124m\"\u001b[39m] \u001b[38;5;241m=\u001b[39m snapshot_callback\n\u001b[1;32m    372\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m--> 373\u001b[0m     component_outputs \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_run_component(\n\u001b[1;32m    374\u001b[0m         component_name\u001b[38;5;241m=\u001b[39mcomponent_name,\n\u001b[1;32m    375\u001b[0m         component\u001b[38;5;241m=\u001b[39mcomponent,\n\u001b[1;32m    376\u001b[0m         inputs\u001b[38;5;241m=\u001b[39mcomponent_inputs,  \u001b[38;5;66;03m# the inputs to the current component\u001b[39;00m\n\u001b[1;32m    377\u001b[0m         component_visits\u001b[38;5;241m=\u001b[39mcomponent_visits,\n\u001b[1;32m    378\u001b[0m         parent_span\u001b[38;5;241m=\u001b[39mspan,\n\u001b[1;32m    379\u001b[0m         \u001b[38;5;66;03m# A break point is provided to stop the pipeline at a specific component\u001b[39;00m\n\u001b[1;32m    380\u001b[0m         break_point\u001b[38;5;241m=\u001b[39mbreak_point \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(break_point, Breakpoint) \u001b[38;5;28;01melse\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m    381\u001b[0m     )\n\u001b[1;32m    382\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m (BreakpointException, PipelineRuntimeError) \u001b[38;5;28;01mas\u001b[39;00m error:\n\u001b[1;32m    383\u001b[0m     saved_break_point: Breakpoint \u001b[38;5;241m|\u001b[39m AgentBreakpoint\n",
+            "File \u001b[0;32m/opt/anaconda3/lib/python3.13/site-packages/haystack/core/pipeline/pipeline.py:100\u001b[0m, in \u001b[0;36mPipeline._run_component\u001b[0;34m(component_name, component, inputs, component_visits, parent_span, break_point)\u001b[0m\n\u001b[1;32m     98\u001b[0m \u001b[38;5;66;03m# Catch all other exceptions and wrap them in a PipelineRuntimeError\u001b[39;00m\n\u001b[1;32m     99\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mException\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m error:\n\u001b[0;32m--> 100\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m PipelineRuntimeError\u001b[38;5;241m.\u001b[39mfrom_exception(component_name, instance\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m, error) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21;01merror\u001b[39;00m\n\u001b[1;32m    102\u001b[0m component_visits[component_name] \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;241m1\u001b[39m\n\u001b[1;32m    104\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(component_output, Mapping):\n",
+            "\u001b[0;31mPipelineRuntimeError\u001b[0m: The following component failed to run:\nComponent name: 'generator'\nComponent type: 'OpenAIGenerator'\nError: Error code: 429 - {'error': {'message': 'You exceeded your current quota, please check your plan and billing details. For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors.', 'type': 'insufficient_quota', 'param': None, 'code': 'insufficient_quota'}}"
+          ]
+        }
+      ],
       "source": [
         "from haystack import Pipeline\n",
         "\n",
@@ -203,8 +366,8 @@
         "pipeline.add_component(name=\"hyde\", instance=hyde)\n",
         "\n",
         "pipeline.connect(\"prompt_builder\", \"generator\")\n",
-        "pipeline.connect(\"generator.replies\", \"adapter.answers\")\n",
-        "pipeline.connect(\"adapter.output\", \"embedder.documents\")\n",
+        "pipeline.connect(\"generator.replies\", \"adapter.replies\")\n",
+        "pipeline.connect(\"adapter.documents\", \"embedder.documents\")\n",
         "pipeline.connect(\"embedder.documents\", \"hyde.documents\")\n",
         "\n",
         "query = \"What should I do if I have a fever?\"\n",
@@ -213,7 +376,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 8,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -221,7 +384,19 @@
         "id": "AtR8JLUmKqwI",
         "outputId": "80cec7d3-e66b-487d-8c05-a4f362146645"
       },
-      "outputs": [],
+      "outputs": [
+        {
+          "ename": "NameError",
+          "evalue": "name 'result' is not defined",
+          "output_type": "error",
+          "traceback": [
+            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+            "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+            "Cell \u001b[0;32mIn[8], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;28mprint\u001b[39m(result[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mhyde\u001b[39m\u001b[38;5;124m\"\u001b[39m])\n",
+            "\u001b[0;31mNameError\u001b[0m: name 'result' is not defined"
+          ]
+        }
+      ],
       "source": [
         "print(result[\"hyde\"])"
       ]
@@ -253,7 +428,6 @@
       "outputs": [],
       "source": [
         "from haystack import Pipeline, component, Document, default_to_dict, default_from_dict\n",
-        "from haystack.components.converters import OutputAdapter\n",
         "from haystack.components.embedders.sentence_transformers_document_embedder import SentenceTransformersDocumentEmbedder\n",
         "from haystack.components.generators.openai import OpenAIGenerator\n",
         "from haystack.components.builders import PromptBuilder\n",
@@ -264,6 +438,15 @@
         "\n",
         "\n",
         "@component\n",
+        "class RepliesToDocuments:\n",
+        "    @component.output_types(documents=List[Document])\n",
+        "    def run(self, replies: List[Any]):\n",
+        "        docs = []\n",
+        "        for reply in replies:\n",
+        "            content = reply.text if hasattr(reply, \"text\") else str(reply)\n",
+        "            docs.append(Document(content=content))\n",
+        "        return {\"documents\": docs}\n",
+        "    \n",
         "class HypotheticalDocumentEmbedder:\n",
         "\n",
         "    def __init__(\n",
@@ -289,7 +472,7 @@
         "            \"\"\"\n",
         "        )\n",
         "\n",
-        "        self.adapter = OutputAdapter(\n",
+        "        self.adapter = RepliesToDocuments(\n",
         "            template=\"{{answers | build_doc}}\",\n",
         "            output_type=List[Document],\n",
         "            custom_filters={\"build_doc\": lambda data: [Document(content=d) for d in data]},\n",
@@ -303,8 +486,8 @@
         "        self.pipeline.add_component(name=\"adapter\", instance=self.adapter)\n",
         "        self.pipeline.add_component(name=\"embedder\", instance=self.embedder)\n",
         "        self.pipeline.connect(\"prompt_builder\", \"generator\")\n",
-        "        self.pipeline.connect(\"generator.replies\", \"adapter.answers\")\n",
-        "        self.pipeline.connect(\"adapter.output\", \"embedder.documents\")\n",
+        "        self.pipeline.connect(\"generator.replies\", \"adapter.replies\")\n",
+        "        self.pipeline.connect(\"adapter.documents\", \"embedder.documents\")\n",
         "\n",
         "    def to_dict(self) -> Dict[str, Any]:\n",
         "        data = default_to_dict(\n",
@@ -483,11 +666,21 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "Python 3",
+      "display_name": "base",
+      "language": "python",
       "name": "python3"
     },
     "language_info": {
-      "name": "python"
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.13.5"
     },
     "widgets": {
       "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
### Proposed Changes

This PR replaces `OutputAdapter` in the `using_hyde_for_improved_retrieval`
notebook with a small custom component that converts generator replies into
`Document` objects.

### How did you test it?

I ran the updated notebook cells locally and verified that the pipeline still
executes and produces document inputs for the embedder.

### Notes for the reviewer

I focused on one notebook first to avoid changing cases where these components
may still affect retrieval behavior rather than just pipeline wiring.