### PR TITLE
Gemma 4 notebook

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -60,7 +60,7 @@ topics = ["Function Calling", "Chat", "Agents"]
 outdated = true
 
 [[cookbook]]
-title = "Build with Gemma and Haystack"
+title = "Build with Gemma 4 and Haystack"
 notebook = "gemma_chat_rag.ipynb"
 topics = ["RAG", "Agents", "Multimodal"]
 

--- a/index.toml
+++ b/index.toml
@@ -62,7 +62,7 @@ outdated = true
 [[cookbook]]
 title = "Build with Gemma and Haystack"
 notebook = "gemma_chat_rag.ipynb"
-topics = ["RAG"]
+topics = ["RAG", "Agents", "Multimodal"]
 
 [[cookbook]]
 title = "Build with Llama Stack and Haystack Agent"

--- a/index.toml
+++ b/index.toml
@@ -63,6 +63,7 @@ outdated = true
 title = "Build with Gemma 4 and Haystack"
 notebook = "gemma_chat_rag.ipynb"
 topics = ["RAG", "Agents", "Multimodal"]
+new = true
 
 [[cookbook]]
 title = "Build with Llama Stack and Haystack Agent"
@@ -304,7 +305,6 @@ topics = ["Function Calling", "Agents"]
 [[cookbook]]
 title = "Introduction to Multimodal Text Generation"
 notebook = "multimodal_intro.ipynb"
-new = true
 topics = ["Multimodal"]
 
 [[cookbook]]
@@ -321,13 +321,11 @@ topics = ["Observability", "Evaluation", "RAG"]
 title = "AI Guardrails: Content Moderation and Safety with Open Language Models"
 notebook = "safety_moderation_open_lms.ipynb"
 topics = ["Guardrails", "Evaluation", "RAG"]
-new = true
 
 [[cookbook]]
 title = "Build Browser Agents with Gemini + Playwright MCP"
 notebook = "browser_agents.ipynb"
 topics = ["Agents", "MCP"]
-new = true
 
 [[cookbook]]
 title = "Calculating a Hallucination Score with the OpenAIChatGenerator"


### PR DESCRIPTION
Fixes https://github.com/deepset-ai/haystack-cookbook/issues/219

Adding a notebook with some simple use cases about Gemma 4

For the moment, the notebook filename is still `gemma_chat_rag`. I'd like to change it but IDK how this plays with Search engines... Let me know...

Use this preview: https://app.reviewnb.com/deepset-ai/haystack-cookbook/blob/gemma4/notebooks/gemma_chat_rag.ipynb/

(the diff seems to be broken but in any case this is almost all new content)