### PR TITLE
build: add supply chain hardening via uv exclude-newer and dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    cooldown:
+      default-days: 1

--- a/uv.toml
+++ b/uv.toml
@@ -1,0 +1,4 @@
+# Exclude package versions published within the last 24 hours to protect against supply chain
+# attacks via compromised dependencies. uv resolves this relative to the current clock at
+# install/lock time, so no manual date updates are needed.
+exclude-newer = "24 hours"


### PR DESCRIPTION
### Related Issues

- Similar to Haystack PR https://github.com/deepset-ai/haystack/pull/11170
- Similar to Haystack Core Integrations PR https://github.com/deepset-ai/haystack-core-integrations/pull/3258
- Similar to Haystack Experimental PR https://github.com/deepset-ai/haystack-experimental/pull/474

Given the short time window of typical supply-chain attacks (e.g. the compromised `mistralai` 2.4.6 release was live for ~3 hours on 2026-05-12), we add `uv exclude-newer` and a Dependabot cooldown to the cookbook repo as well.

### Proposed Changes:

- Add `uv.toml` with `exclude-newer = "24 hours"` so any `uv pip install` (e.g. inside notebooks executed in a CI environment) skips packages published within the last day.
- Add `.github/dependabot.yml` with `package-ecosystem: github-actions`, `interval: daily`, and `cooldown.default-days: 1` so Dependabot won't open action bump PRs for versions published less than 1 day ago. The cookbook has no `pip` dependencies declared at the repo level and no `pip install` steps in CI workflows, so no `--uploaded-prior-to` flag is needed.

### How did you test it?

N/A — config-only changes. Workflows in this repo do not install Python packages, so there is nothing to exercise locally.

### Notes for the reviewer

The cookbook differs from the haystack / haystack-experimental / haystack-core-integrations repos in that none of its CI workflows run `pip install`; the only Python step (`verify_index.py`) uses stdlib only. So the pip `--uploaded-prior-to=P1D` changes from the sibling PRs don't apply here. The `uv.toml` is still added defensively for anyone running notebooks via uv.

### Checklist

- I have read the contributors guidelines and the code of conduct.
- I've used one of the [conventional commit types](https://www.conventionalcommits.org/en/v1.0.0/) for my PR title: `build:`.