### PR TITLE
Update web-enhanced self-reflecting agent notebook for new serperdev-haystack package

### DIFF
--- a/notebooks/web_enhanced_self_reflecting_agent.ipynb
+++ b/notebooks/web_enhanced_self_reflecting_agent.ipynb
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -U ollama-haystack git+https://github.com/deepset-ai/haystack.git@main"
+    "!pip install -U ollama-haystack serperdev-haystack trafilatura 'nltk>=3.9.1' git+https://github.com/deepset-ai/haystack.git@main"
    ]
   },
   {
@@ -138,7 +138,7 @@
     "indexing_pipeline.run({\n",
     "    \"fetcher\": {\n",
     "        \"urls\": [\n",
-    "            \"https://docs.haystack.deepset.ai/docs/generators-vs-chat-generators\",\n",
+    "            \"https://docs.haystack.deepset.ai/docs/choosing-the-right-generator\",\n",
     "            \"https://docs.haystack.deepset.ai/docs/ollamagenerator\",\n",
     "            \"https://haystack.deepset.ai/overview/quick-start\",\n",
     "            \"https://haystack.deepset.ai/overview/intro\"\n",
@@ -282,7 +282,7 @@
    "source": [
     "from haystack import Pipeline\n",
     "from haystack.components.retrievers.in_memory import InMemoryBM25Retriever\n",
-    "from haystack.components.websearch import SerperDevWebSearch\n",
+    "from haystack_integrations.components.websearch.serperdev import SerperDevWebSearch\n",
     "from haystack.components.builders import PromptBuilder\n",
     "from haystack_integrations.components.generators.ollama import OllamaGenerator\n",
     "\n",


### PR DESCRIPTION
### Related Issues

- part of https://github.com/deepset-ai/haystack-private/issues/369

### Proposed Changes:
- update `web_enhanced_self_reflecting_agent.ipynb` for the new `serperdev-haystack` package: `SerperDevWebSearch` moved from Haystack core to [haystack-core-integrations](https://github.com/deepset-ai/haystack-core-integrations/pull/3425); import changed to `from haystack_integrations.components.websearch.serperdev import SerperDevWebSearch`
- fix pre-existing breakages found while running the notebook on haystack main:
  - add `trafilatura` and `nltk>=3.9.1` to the install command (now required by `HTMLToDocument` and `DocumentSplitter(split_by="sentence")`)
  - replace the stale docs URL `generators-vs-chat-generators` (now a meta-refresh redirect stub that extracts to empty content and crashes the indexing pipeline) with `choosing-the-right-generator`

### How did you test it?
- ran the full notebook locally (nbconvert + ipython) with a real `SERPERDEV_API_KEY`, local Ollama running `gemma2:9b-instruct-q4_1`, and `serperdev-haystack` installed from the integration branch: both queries complete; the second query exercises the web-search path via the new package

### Notes for the reviewer
- `serperdev-haystack` is released on PyPI 
- If there are any notebooks that you plan to drop anyway, let's see if that can be done before we create new integrations. Otherwise we'll try to make old notebooks work that will soon be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
