### PR TITLE
fix: update rag_eval_ragas notebook for ragas>=0.4.3 API

### DIFF
--- a/notebooks/rag_eval_ragas.ipynb
+++ b/notebooks/rag_eval_ragas.ipynb
@@ -101,8 +101,10 @@
     "from haystack.components.builders import AnswerBuilder\n",
     "from haystack_integrations.components.evaluators.ragas import RagasEvaluator\n",
     "\n",
-    "from ragas.llms import HaystackLLMWrapper\n",
-    "from ragas.metrics import AnswerRelevancy, ContextPrecision, Faithfulness"
+    "from openai import AsyncOpenAI\n",
+    "from ragas.llms import llm_factory\n",
+    "from ragas.embeddings import embedding_factory\n",
+    "from ragas.metrics.collections import AnswerRelevancy, ContextPrecision, Faithfulness"
    ]
   },
   {
@@ -117,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "id": "C3VuBdDC7nW-"
    },
@@ -149,19 +151,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "id": "f5-2BQi67nW-"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Calculating embeddings: 1it [00:00,  1.67it/s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Sets up an in-memory store to hold documents\n",
     "document_store = InMemoryDocumentStore()\n",
@@ -207,7 +201,9 @@
    "source": [
     "#### Configuring RagasEvaluator Component\n",
     "\n",
-    "Pass all the Ragas metrics you want to use for evaluation, ensuring that all the necessary information to calculate each selected metric is provided.\n",
+    "Create a Ragas LLM and embeddings instance using `llm_factory` and `embedding_factory`, then pass\n",
+    "fully-configured metric objects to `RagasEvaluator`. Each metric receives its LLM (and embeddings\n",
+    "where required) at construction time.\n",
     "\n",
     "For example:\n",
     "\n",
@@ -226,12 +222,16 @@
    },
    "outputs": [],
    "source": [
-    "llm = OpenAIChatGenerator(model=\"gpt-4o-mini\")\n",
-    "evaluator_llm = HaystackLLMWrapper(llm)\n",
+    "client = AsyncOpenAI()\n",
+    "evaluator_llm = llm_factory(\"gpt-4o-mini\", client=client)\n",
+    "evaluator_embeddings = embedding_factory(\"openai\", model=\"text-embedding-3-small\", client=client)\n",
     "\n",
     "ragas_evaluator = RagasEvaluator(\n",
-    "    ragas_metrics=[AnswerRelevancy(), ContextPrecision(), Faithfulness()],\n",
-    "    evaluator_llm=evaluator_llm,\n",
+    "    ragas_metrics=[\n",
+    "        AnswerRelevancy(llm=evaluator_llm, embeddings=evaluator_embeddings),\n",
+    "        ContextPrecision(llm=evaluator_llm),\n",
+    "        Faithfulness(llm=evaluator_llm),\n",
+    "    ]\n",
     ")"
    ]
   },
@@ -247,37 +247,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "id": "S4EVs74m7nW-"
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<haystack.core.pipeline.pipeline.Pipeline object at 0x16a0d1790>\n",
-       "🚅 Components\n",
-       "  - text_embedder: OpenAITextEmbedder\n",
-       "  - retriever: InMemoryEmbeddingRetriever\n",
-       "  - prompt_builder: ChatPromptBuilder\n",
-       "  - llm: OpenAIChatGenerator\n",
-       "  - answer_builder: AnswerBuilder\n",
-       "  - ragas_evaluator: RagasEvaluator\n",
-       "🛤️ Connections\n",
-       "  - text_embedder.embedding -> retriever.query_embedding (List[float])\n",
-       "  - retriever.documents -> prompt_builder.documents (List[Document])\n",
-       "  - retriever.documents -> answer_builder.documents (List[Document])\n",
-       "  - retriever.documents -> ragas_evaluator.documents (List[Document])\n",
-       "  - prompt_builder.prompt -> llm.messages (List[ChatMessage])\n",
-       "  - llm.replies -> answer_builder.replies (List[ChatMessage])\n",
-       "  - llm.replies -> ragas_evaluator.response (List[ChatMessage])"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Creating the Pipeline\n",
     "rag_pipeline = Pipeline()\n",
@@ -302,7 +276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -324,28 +298,11 @@
     "id": "NwiyoIJq7nW_",
     "outputId": "0973ca10-8d30-423f-8eab-7896ad588500"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Evaluating: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:18<00:00,  6.33s/it]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Meta AI’s LLaMA models stand out due to their open-source nature, allowing researchers and developers to access high-quality models for free. This accessibility fosters innovation and experimentation, making it easier for individuals and organizations to collaborate and advance AI development without the constraints of expensive resources. Their strong performance further enhances their appeal in the AI community. \n",
-      "\n",
-      "{'answer_relevancy': 0.9758, 'context_precision': 1.0000, 'faithfulness': 1.0000}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "question = \"What makes Meta AI’s LLaMA models stand out?\"\n",
+    "question = \"What makes Meta AI's LLaMA models stand out?\"\n",
     "\n",
-    "reference = \"Meta AI’s LLaMA models stand out for being open-source, supporting innovation and experimentation due to their accessibility and strong performance.\"\n",
+    "reference = \"Meta AI's LLaMA models stand out for being open-source, supporting innovation and experimentation due to their accessibility and strong performance.\"\n",
     "\n",
     "\n",
     "result = rag_pipeline.run(\n",
@@ -360,7 +317,8 @@
     ")\n",
     "\n",
     "print(result['answer_builder']['answers'][0].data, '\\n')\n",
-    "print(result['ragas_evaluator']['result'])"
+    "scores = {k: round(v.value, 4) for k, v in result['ragas_evaluator']['result'].items()}\n",
+    "print(scores)"
    ]
   },
   {
@@ -381,41 +339,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "id": "316LMozo7nW_"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Calculating embeddings: 1it [00:00,  3.14it/s]\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<haystack.core.pipeline.pipeline.Pipeline object at 0x16a77bbd0>\n",
-       "🚅 Components\n",
-       "  - text_embedder: OpenAITextEmbedder\n",
-       "  - retriever: InMemoryEmbeddingRetriever\n",
-       "  - prompt_builder: ChatPromptBuilder\n",
-       "  - llm: OpenAIChatGenerator\n",
-       "  - answer_builder: AnswerBuilder\n",
-       "🛤️ Connections\n",
-       "  - text_embedder.embedding -> retriever.query_embedding (List[float])\n",
-       "  - retriever.documents -> prompt_builder.documents (List[Document])\n",
-       "  - retriever.documents -> answer_builder.documents (List[Document])\n",
-       "  - prompt_builder.prompt -> llm.messages (List[ChatMessage])\n",
-       "  - llm.replies -> answer_builder.replies (List[ChatMessage])"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Initialize components for RAG pipeline\n",
     "document_store = InMemoryDocumentStore()\n",
@@ -480,7 +408,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "id": "dGQp5XbB7nW_"
    },
@@ -533,11 +461,14 @@
     "id": "5WM9Nzia7nW_"
    },
    "source": [
-    "> When constructing the `evals_list`, it is important to align the keys in the single_turn dictionary with the attributes defined in the Ragas [SingleTurnSample](https://docs.ragas.io/en/stable/references/evaluation_schema/#ragas.dataset_schema.SingleTurnSample). This ensures compatibility with the Ragas evaluation framework. Use the retrieved documents and pipeline outputs to populate these fields accurately, as demonstrated in the provided code snippet.\n",
+    "> When constructing the `evals_list`, it is important to align the keys in the single_turn dictionary\n",
+    "> with the attributes defined in the Ragas [SingleTurnSample](https://docs.ragas.io/en/stable/references/evaluation_schema/#ragas.dataset_schema.SingleTurnSample).\n",
+    "> This ensures compatibility with the Ragas evaluation framework. Use the retrieved documents and\n",
+    "> pipeline outputs to populate these fields accurately, as demonstrated in the provided code snippet.\n",
     "\n",
-    "#### Evaluating the pipeline using Ragas EvaluationDataset\n",
-    "The extracted dataset is converted into a Ragas [EvaluationDataset](https://docs.ragas.io/en/stable/references/evaluation_schema/#ragas.dataset_schema.EvaluationDataset) so that Ragas can process it.\n",
-    "We then initialize an LLM evaluator using the HaystackLLMWrapper. Finally, we call Ragas's evaluate() function with our evaluation dataset, three metrics, and the LLM evaluator.\n"
+    "#### Evaluating the pipeline using RagasEvaluator\n",
+    "We create a fresh `RagasEvaluator` and call `.run()` for each sample directly, collecting the\n",
+    "per-sample scores into a pandas DataFrame for easy inspection."
    ]
   },
   {
@@ -562,135 +493,40 @@
      ]
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Evaluating: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 9/9 [00:23<00:00,  2.57s/it]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'answer_relevancy': 0.9679, 'context_precision': 1.0000, 'faithfulness': 1.0000}\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>user_input</th>\n",
-       "      <th>retrieved_contexts</th>\n",
-       "      <th>response</th>\n",
-       "      <th>reference</th>\n",
-       "      <th>answer_relevancy</th>\n",
-       "      <th>context_precision</th>\n",
-       "      <th>faithfulness</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Who are the major players in the large languag...</td>\n",
-       "      <td>[In the rapidly advancing field of artificial ...</td>\n",
-       "      <td>The major players in the large language model ...</td>\n",
-       "      <td>The major players include OpenAI (GPT Series),...</td>\n",
-       "      <td>0.999999</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>1.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>What is Microsoft’s Azure AI platform known for?</td>\n",
-       "      <td>[Microsoft’s Azure AI platform is famous for i...</td>\n",
-       "      <td>Microsoft’s Azure AI platform is known for int...</td>\n",
-       "      <td>Microsoft’s Azure AI platform is known for int...</td>\n",
-       "      <td>1.000000</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>1.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>What kind of models does Cohere provide?</td>\n",
-       "      <td>[Cohere is well-known for its language models ...</td>\n",
-       "      <td>Cohere provides language models tailored for b...</td>\n",
-       "      <td>Cohere provides language models tailored for b...</td>\n",
-       "      <td>0.903765</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>1.0</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                          user_input  \\\n",
-       "0  Who are the major players in the large languag...   \n",
-       "1   What is Microsoft’s Azure AI platform known for?   \n",
-       "2           What kind of models does Cohere provide?   \n",
-       "\n",
-       "                                  retrieved_contexts  \\\n",
-       "0  [In the rapidly advancing field of artificial ...   \n",
-       "1  [Microsoft’s Azure AI platform is famous for i...   \n",
-       "2  [Cohere is well-known for its language models ...   \n",
-       "\n",
-       "                                            response  \\\n",
-       "0  The major players in the large language model ...   \n",
-       "1  Microsoft’s Azure AI platform is known for int...   \n",
-       "2  Cohere provides language models tailored for b...   \n",
-       "\n",
-       "                                           reference  answer_relevancy  \\\n",
-       "0  The major players include OpenAI (GPT Series),...          0.999999   \n",
-       "1  Microsoft’s Azure AI platform is known for int...          1.000000   \n",
-       "2  Cohere provides language models tailored for b...          0.903765   \n",
-       "\n",
-       "   context_precision  faithfulness  \n",
-       "0                1.0           1.0  \n",
-       "1                1.0           1.0  \n",
-       "2                1.0           1.0  "
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from ragas import evaluate\n",
-    "from ragas.dataset_schema import EvaluationDataset\n",
+    "import pandas as pd\n",
     "\n",
-    "evaluation_dataset = EvaluationDataset.from_list(evals_list)\n",
+    "client = AsyncOpenAI()\n",
+    "evaluator_llm = llm_factory(\"gpt-4o-mini\", client=client)\n",
+    "evaluator_embeddings = embedding_factory(\"openai\", model=\"text-embedding-3-small\", client=client)\n",
     "\n",
-    "llm = OpenAIChatGenerator(model=\"gpt-4o-mini\")\n",
-    "evaluator_llm = HaystackLLMWrapper(llm)\n",
-    "\n",
-    "result = evaluate(\n",
-    "    dataset=evaluation_dataset,\n",
-    "    metrics=[AnswerRelevancy(), ContextPrecision(), Faithfulness()],\n",
-    "    llm=evaluator_llm,\n",
+    "standalone_evaluator = RagasEvaluator(\n",
+    "    ragas_metrics=[\n",
+    "        AnswerRelevancy(llm=evaluator_llm, embeddings=evaluator_embeddings),\n",
+    "        ContextPrecision(llm=evaluator_llm),\n",
+    "        Faithfulness(llm=evaluator_llm),\n",
+    "    ]\n",
     ")\n",
     "\n",
-    "print(result)\n",
-    "result.to_pandas()"
+    "rows = []\n",
+    "for sample in evals_list:\n",
+    "    eval_result = standalone_evaluator.run(\n",
+    "        query=sample[\"user_input\"],\n",
+    "        response=sample[\"response\"],\n",
+    "        documents=sample[\"retrieved_contexts\"],\n",
+    "        reference=sample[\"reference\"],\n",
+    "    )\n",
+    "    row = {\n",
+    "        \"user_input\": sample[\"user_input\"],\n",
+    "        \"response\": sample[\"response\"],\n",
+    "        **{k: round(v.value, 4) for k, v in eval_result[\"result\"].items()},\n",
+    "    }\n",
+    "    rows.append(row)\n",
+    "\n",
+    "df = pd.DataFrame(rows)\n",
+    "print(df[[\"user_input\", \"answer_relevancy\", \"context_precision\", \"faithfulness\"]])\n",
+    "df"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Fixes #285 - updates the `rag_eval_ragas` cookbook notebook to work with `ragas>=0.4.3`, which introduced breaking API changes.

**What changed:**
- Replaced `HaystackLLMWrapper` (removed in ragas 0.4.x) with `llm_factory` and `embedding_factory` from the native ragas API
- Each metric now receives its LLM at construction time, e.g. `AnswerRelevancy(llm=llm, embeddings=embeddings)`
- Updated imports to use `ragas.metrics.collections` (non-deprecated path in 0.4.x)
- Replaced the standalone `ragas.evaluate()` section with `RagasEvaluator.run()` per sample
- Cleared all stale cell outputs

**Tested:**
- Ran end-to-end against real OpenAI after deepset-ai/haystack-core-integrations#3207 merged
- RagasEvaluator in pipeline returns valid scores for answer_relevancy, context_precision, faithfulness
- All 31 unit tests in ragas-haystack pass