### PR TITLE
chore: handle archived haystack-experimental

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -167,8 +167,6 @@ topics = ["Customization", "Prompting"]
 [[cookbook]]
 title = "Advanced RAG: Query Expansion"
 notebook = "query-expansion.ipynb"
-experimental = true
-discuss = "https://github.com/deepset-ai/haystack-experimental/discussions/346"
 topics = ["Advanced Retrieval", "RAG"]
 
 [[cookbook]]
@@ -266,9 +264,7 @@ topics = ["Function Calling", "Chat", "Agents"]
 [[cookbook]]
 title = "Evaluating AI with Haystack"
 notebook = "evaluating_ai_with_haystack.ipynb"
-experimental = true
 topics = ["Evaluation"]
-discuss = "https://github.com/deepset-ai/haystack-experimental/discussions/74"
 
 [[cookbook]]
 title = "Multimodal Agent with fastRAG and Haystack"
@@ -385,9 +381,7 @@ new = true
 title = "Using Mem0 Memory Store with Haystack Agents"
 notebook = "memory_store_mem0.ipynb"
 topics = ["Agents", "Chat", "Memory"]
-experimental = true
 new = true
-discuss = "https://github.com/deepset-ai/haystack-experimental/discussions/436"
 
 [[cookbook]]
 title = "LinkedIn, Company Intelligence & Lead Enrichment with Haystack, MongoDB Atlas, and Bright Data"

--- a/notebooks/hallucination_score_calculator.ipynb
+++ b/notebooks/hallucination_score_calculator.ipynb
@@ -9,7 +9,9 @@
     "\n",
     "In this cookbook we will show how to calculate a hallucination risk based on the research paper [LLMs are Bayesian, in Expectation, not in Realization](https://arxiv.org/abs/2507.11768) and this GitHub repo, https://github.com/leochlon/hallbayes.\n",
     "\n",
-    "In this notebook, we'll use the OpenAIChatGenerator from haystack-experimental."
+    "In this notebook, we'll use the `OpenAIChatGenerator` from `haystack-experimental`.\n",
+    "\n",
+    "> ⚠️ **Archived package**: `haystack-experimental` is archived and no longer maintained. This experiment was not adopted into Haystack core, so this notebook pins the final release, `haystack-experimental==0.19.0.post1`. It stays installable from PyPI, but is only tested against the version of Haystack that was current in February 2026."
    ]
   },
   {
@@ -27,7 +29,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install haystack-experimental -q"
+    "%pip install \"haystack-experimental==0.19.0.post1\" -q"
    ]
   },
   {

--- a/notebooks/query-expansion.ipynb
+++ b/notebooks/query-expansion.ipynb
@@ -93,7 +93,7 @@
    "source": [
     "## The Process of Query Expansion\n",
     "\n",
-    "First, let's import the `QueryExpander` from **Haystack Experimental**.\n",
+    "First, let's import the `QueryExpander` from Haystack.\n",
     "\n",
     "Next, we’ll create a `QueryExpander` instance. This component generates a specified number (default is 4) of additional queries that are similar to the original user query. It returns `queries`, which include the original query plus the generated similar ones."
    ]
@@ -106,7 +106,7 @@
    },
    "outputs": [],
    "source": [
-    "from haystack_experimental.components.query.query_expander import QueryExpander"
+    "from haystack.components.query import QueryExpander"
    ]
   },
   {


### PR DESCRIPTION
### Related Issues

- None. Part of archiving [deepset-ai/haystack-experimental](https://github.com/deepset-ai/haystack-experimental).

### Proposed Changes:

- `hallucination_score_calculator`: the hallucination-scoring generator was not adopted into core, so pin `haystack-experimental==0.19.0.post1` and add an archived note.
- `query-expansion`: **was already broken** — it imported `QueryExpander` from `haystack_experimental` while the install cell only installed `haystack-ai`. `QueryExpander` graduated to core, so import it from `haystack.components.query`.
- `index.toml`: drop `experimental = true` and the archived-repo `discuss` links from three entries whose features are no longer experimental — query-expansion (graduated to core), memory_store_mem0 (graduated to the mem0 integration), evaluating_ai_with_haystack (uses no experimental component). `discuss` alone renders the "Discuss Experimental Feature" button on haystack-home, so both keys have to go.

### How did you test it?

Notebook JSON and `index.toml` validated as parseable. Not executed (needs an OpenAI key).

### Notes for the reviewer

`openapitool` deliberately keeps its flags — it is a genuinely discontinued experiment and already marked `outdated`.
